### PR TITLE
Send in the request meta for headers when creating the authorization response

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -123,9 +123,9 @@ class OAuthLibCore:
 
             # add current user to credentials. this will be used by OAUTH2_VALIDATOR_CLASS
             credentials["user"] = request.user
-
             headers, body, status = self.server.create_authorization_response(
-                uri=uri, scopes=scopes, credentials=credentials, body=body)
+                uri=uri, scopes=scopes, credentials=credentials, body=body, headers=request.META
+            )
             redirect_uri = headers.get("Location", None)
 
             return redirect_uri, headers, body, status


### PR DESCRIPTION
https://app.clubhouse.io/greenspace/story/26294/properly-add-request-meta-to-authorization-response

## Description of the Change
Before we couldn't do custom issuer domains because of an issue where the request was being sanitized and loosing the request headers. This PR uses the request.META before the sanitation occurs to persist the headers into the lower areas of the code.

This module leverages the oauthlib to construct this response so you will need to look here if you wish to see how it was moving the headers around.
https://oauthlib.readthedocs.io/en/latest/_modules/oauthlib/oauth2/rfc6749/endpoints/authorization.html#AuthorizationEndpoint.create_authorization_response

**Note:**
Reminder that this is a library and not the greenspace project, we dont expect to verify acceptance style tests in this repo. I will create a release for 1.4.1 and then update the greenspace requirements to include these changes.

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] ~`CHANGELOG.md` updated (only for user relevant changes)~ No api breaking changes on this bug fix
- [x] ~author name in `AUTHORS`~ N/A

## Examples
### Failing test
![Screenshot from 2020-11-17 13-02-54](https://user-images.githubusercontent.com/1335972/99450543-c567ee80-28d5-11eb-9a6c-528cc5fef5dd.png)

## QA Notes (no CICD in this repo)
### How to run all the tests
```bash
tox -e py36-django22
```

### How to run the single test
After following the setup guide in the readme you can run the single new test with the command below.
```bash
tox -e py36-django22 -- tests/test_authorization_code.py::TestAuthorizationCodeTokenView::test_id_token_public_oidc_capable
```