### PR TITLE
Use extract header functionality instead of raw

### DIFF
--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -123,8 +123,9 @@ class OAuthLibCore:
 
             # add current user to credentials. this will be used by OAUTH2_VALIDATOR_CLASS
             credentials["user"] = request.user
+            request_headers = self.extract_headers(request)
             headers, body, status = self.server.create_authorization_response(
-                uri=uri, scopes=scopes, credentials=credentials, body=body, headers=request.META
+                uri=uri, scopes=scopes, credentials=credentials, body=body, headers=request_headers
             )
             redirect_uri = headers.get("Location", None)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-oauth-toolkit
-version = 1.4.0
+version = 1.4.2
 description = OAuth2 Provider for Django
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Description of the Change
Still not 100% sure what is causing the prod issue but after looking into the request.META it might have fields that we shouldn't copy. This PR fixes that by leveraging the existing helper for this.

```python
    def extract_headers(self, request):
        """
        Extracts headers from the Django request object
        :param request: The current django.http.HttpRequest object
        :return: a dictionary with OAuthLib needed headers
        """
        headers = request.META.copy()
        if "wsgi.input" in headers:
            del headers["wsgi.input"]
        if "wsgi.errors" in headers:
            del headers["wsgi.errors"]
        if "HTTP_AUTHORIZATION" in headers:
            headers["Authorization"] = headers["HTTP_AUTHORIZATION"]

        return headers
```

## Checklist
- [x] refine usage of headers
- [x] adjust the version number for next release