### PR TITLE
IAT does not account for timezone

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -800,7 +800,7 @@ class OAuth2Validator(RequestValidator):
             "iss": self.get_oidc_issuer_endpoint(request),
             "aud": request.client_id,
             "exp": int(dateformat.format(expiration_time, "U")),
-            "iat": int(dateformat.format(datetime.utcnow(), "U")),
+            "iat": int(dateformat.format(timezone.now(), "U")),
             "auth_time": int(dateformat.format(request.user.last_login, "U")),
         })
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-oauth-toolkit
-version = 1.4.2
+version = 1.4.3
 description = OAuth2 Provider for Django
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
https://app.clubhouse.io/greenspace/story/29811/exp-and-iat-are-currently-not-correctly-time-zoned

## Description of the Change
Use timezone.now() instead of utcnow()
## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added

